### PR TITLE
feat: support more properties for deploy-website

### DIFF
--- a/alibaba/oss/deploy-website/main.tf
+++ b/alibaba/oss/deploy-website/main.tf
@@ -1,43 +1,70 @@
 terraform {
   required_providers {
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
       version = "4.20.0"
     }
   }
 }
 
-locals {
-  website_source = "static"
-}
-
 resource "null_resource" "default" {
-
   provisioner "local-exec" {
-    command = "rm -rf ${local.website_source} && git clone ${var.static_web_url} ${local.website_source} && ossutil cp -r ${local.website_source} oss://${var.bucket} --access-key-id=$ALICLOUD_ACCESS_KEY --access-key-secret=$ALICLOUD_SECRET_KEY --endpoint=${var.endpoint} --force"
-
+    command = <<EOF
+apk update
+apk add build-base libtool automake autoconf nasm pkgconfig util-linux git
+rm -rf ${var.src_folder}
+git clone ${var.src_url}
+cd ${var.src_folder}
+${var.prepare_build_env_cmd}
+${var.build_cmd}
+ossutil cp -r ${var.dst_folder} oss://${var.bucket} --access-key-id=$ALICLOUD_ACCESS_KEY --access-key-secret=$ALICLOUD_SECRET_KEY --endpoint=${var.endpoint} --force
+    EOF
   }
 }
 
-variable "static_web_url" {
-  description = "The URL of the static website"
-  type = string
-  default = "https://github.com/cloudacademy/static-website-example.git"
-}
-
-
 variable "bucket" {
   description = "OSS bucket name"
-  default = "vela-website"
-  type = string
+  type        = string
+  default     = "vela-deploy-website-example"
 }
 
 variable "endpoint" {
   description = "OSS bucket endpoint"
-  type = string
+  type        = string
+  default     = "oss-cn-hangzhou.aliyuncs.com"
+}
+
+variable "src_url" {
+  description = "Source code repo on GitHub"
+  type    = string
+  default = "https://github.com/kubevela/kubevela.io.git"
+}
+
+variable "src_folder" {
+  description = "Source code root folder path"
+  type    = string
+  default = "kubevela.io/"
+}
+
+variable "prepare_build_env_cmd" {
+  description = "Required commands for prepare build env"
+  type    = string
+  default = "apk add nodejs npm && npm install --global yarn"
+}
+
+variable "build_cmd" {
+  description = "Commands for build source code"
+  type    = string
+  default = "yarn install && yarn build"
+}
+
+variable "dst_folder" {
+  description = "Building output folder path"
+  type    = string
+  default = "build/"
 }
 
 output "URL" {
   description = "The URL of the website"
-  value = "https://${var.bucket}.${var.endpoint}"
+  value       = "https://${var.bucket}.${var.endpoint}"
 }


### PR DESCRIPTION
Add variables: 
* `src_url`: The URL of the website source code repository
* `prerequisite_cmd`: Prerequisite commands to setup building env, support Alpine `apk` package manage
* `build_cmd`: Commands for building website source code
* `generated_dir`: Directory name of generated static content

Now, `deploy-website` support source code repository, enable terraform controller to clone git repo, build source code and upload to oss bucket. User would get the static site endpoint.

Example usages:

- application using component `deploy-website`

  ```yaml
  apiVersion: core.oam.dev/v1beta1
  kind: Application
  metadata:
    name: test-app
  spec:
    components:
      - name: test-app-2
        type: deploy-website
        properties:
          bucket: terra-233
          endpoint: oss-cn-hangzhou.aliyuncs.com
          src_url: https://github.com/open-gitops/website.git
          prerequisite_cmd: apk add nodejs npm && npm install --global yarn
          build_cmd: yarn install && yarn build
          generated_dir: public
  ```
- application using component `deploy-website` with `alibaba-oss-website`

  ```yaml
  apiVersion: core.oam.dev/v1beta1
  kind: Application
  metadata:
    name: test-app-v2
  spec:
    components:
      # create oss bucket, config with static site setting
      - name: test-app-3
        type: alibaba-oss-website
        properties:
          bucket: terra-233
          acl: public-read
          index_document: index.html
          error_document: 404.html
          writeConnectionSecretToRef:
            name: oss-website-conn
        outputs:
          - name: bucket
            valueFrom: output.status.apply.outputs.BUCKET_NAME.value
          - name: endpoint
            valueFrom: output.status.apply.outputs.EXTRANET_ENDPOINT.value
      # clone git repo, build source code, upload to oss bucket
      - name: test-app-4
        type: deploy-website
        inputs:
          - from: bucket
            parameterKey: properties.bucket
          - from: endpoint
            parameterKey: properties.endpoint
        properties:
          src_url: https://github.com/open-gitops/website.git
          prerequisite_cmd: apk add nodejs npm && npm install --global yarn
          build_cmd: yarn install && yarn build
          generated_dir: public
  ```

See the screenshots

<details> 

- vela up

<img width="1054" alt="Screen Shot 2022-08-29 at 21 39 02" src="https://user-images.githubusercontent.com/57584831/187332873-27666162-6c4a-4208-9b4c-7bea6754e448.png">

- vela ls

<img width="1331" alt="Screen Shot 2022-08-29 at 21 37 38" src="https://user-images.githubusercontent.com/57584831/187332946-79145b7b-2226-4bca-b844-42bb92c24e4f.png">

- vela status

<img width="400" alt="Screen Shot 2022-08-29 at 21 37 53" src="https://user-images.githubusercontent.com/57584831/187333045-0f7b9a91-0d05-41aa-a60a-d013d76eb5ed.png">

<img width="400" alt="Screen Shot 2022-08-29 at 21 38 35" src="https://user-images.githubusercontent.com/57584831/187333066-af4553b4-4cbb-446d-a964-cb0689512ec6.png">

- endpoint

<img width="1354" alt="Screen Shot 2022-08-29 at 21 41 36" src="https://user-images.githubusercontent.com/57584831/187333117-ed7015b3-d0c8-48bf-9ac3-95c2a2441bfe.png">


</details> 
