### PR TITLE
Feat: add vsphere_folder tf module

### DIFF
--- a/vsphere/folder/main.tf
+++ b/vsphere/folder/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    vsphere = {
+      source  = "hashicorp/vsphere"
+      version = "2.2.0"
+    }
+  }
+}
+
+data "vsphere_datacenter" "dc" {
+}
+
+# resource
+resource "vsphere_folder" "folder" {
+  path          = var.folder_path
+  type          = var.folder_type
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+# output
+output "FOLDER" {
+  value = "folder-${var.folder_type}-${var.folder_path}"
+}
+
+# variable
+variable "folder_path" {
+  description = "The path of the folder to be created"
+  type        = string
+  default     = "terraform-test-folder"
+}
+
+variable "folder_type" {
+  description = "The type of folder to create. Allowed options: `datacenter`, `host`, `vm`, `datastore` and `network`"
+  type        = string
+  default     = "vm"
+}


### PR DESCRIPTION
Separate terraform module from addon's catalog definition, upstream pr: https://github.com/kubevela/catalog/pull/442

per: https://registry.terraform.io/providers/hashicorp/vsphere/latest/docs/resources/folder

test app def:

```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: vsphere-test-folder
spec:
  components:
    - name: folder-comp
      type: vsphere-folder
      properties:
        folder_path: terraform-test-folder
        folder_type: vm
```

screenshot:

![Screenshot_1](https://user-images.githubusercontent.com/57584831/189034903-dc901b31-5cb7-4cac-8806-60d3a67cb177.png)
<img width="560" src="https://user-images.githubusercontent.com/57584831/189034911-648cf8fe-e1f9-4469-a7bf-280e6ba1b58f.png">

![Screenshot_5](https://user-images.githubusercontent.com/57584831/189034916-54a7dfe3-6d74-4dba-a645-74b3f55d3905.png)
